### PR TITLE
cicd error fix

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -10,4 +10,4 @@ docker build -t %image_name% .
 docker run -d --name %container_name% -p 10100:10100 %image_name%
 
 for /f "tokens=1" %%a in ('docker ps ^| findstr biber') do set image_id=%%a
-docker exec -it  %image_id%  /bin/bash -c "pytest"
+docker exec -i  %image_id%  /bin/bash -c "pytest"

--- a/make.sh
+++ b/make.sh
@@ -13,4 +13,4 @@ docker run -d --name $container_name -p 10100:10100 $image_name
 
 ## testing
 img_id=$(docker ps | grep biber | awk '{print $1}')
-docker exec -it $img_id /bin/bash -c "pytest"
+docker exec -i $img_id /bin/bash -c "pytest"

--- a/test.bat
+++ b/test.bat
@@ -1,3 +1,0 @@
-
-echo %image_name%
-

--- a/test.bat
+++ b/test.bat
@@ -1,4 +1,3 @@
-@echo offfor 
-for /f "tokens=1" %%a in ('docker ps ^| findstr biber') do set image_name=%%a
+
 echo %image_name%
 


### PR DESCRIPTION
https://stackoverflow.com/questions/43099116/error-the-input-device-is-not-a-tty

build시 error-the-input-device-is-not-a-tty 뜸
input device가 없어서 -t 옵션이 오류 생기는 듯

제거 