### PR TITLE
refactor: /ping 에서 임베딩 요청 대신 get models 요청을 보내도록 변경

### DIFF
--- a/server/routes/generate.py
+++ b/server/routes/generate.py
@@ -25,14 +25,15 @@ async def generate_message(question: Question):
     try:
         storage_context = StorageContext.from_defaults(persist_dir=embed_path)
         index = load_index_from_storage(storage_context)
-    except FileNotFoundError:
+    except FileNotFoundError:  # 사용자로부터 임베딩 파일을 받지 못했을 때 예외를 표출함
         logging.warning("저장소 내부가 비어 있음")
         return Answer(message="파일이 첨부되지 않았습니다.")
 
     try:
-        if False: # 자연스러운 응답을 생성하는 Completion 모델로 임시 설정
+        if 1 == 0: # chat engine 사용 전에 자연스러운 프롬프트 처리가 필요함
             chat_engine = index.as_chat_engine(chat_mode="condense_question", verbose=True)
             res = chat_engine.chat(message=question.message)
+        # 자연스러운 응답을 생성하는 query engine으로 임시 설정
         query_engine = index.as_query_engine()
         res = query_engine.query(question.message)
 

--- a/server/routes/ping.py
+++ b/server/routes/ping.py
@@ -1,8 +1,9 @@
 import logging
+import os
 
+import requests
+from dotenv import load_dotenv
 from fastapi import APIRouter
-from openai import APIConnectionError
-from llama_index import SimpleDirectoryReader, VectorStoreIndex, OpenAIEmbedding
 
 from ..models.ping import Pong
 
@@ -11,14 +12,12 @@ ping_router = APIRouter()
 
 @ping_router.get("/ping")
 async def ping():
-    OpenAIEmbedding(timeout=5)
+    load_dotenv()
+    base_url = os.getenv("OPENAI_BASE_URL")
     try:
-        docs = SimpleDirectoryReader(
-            input_dir="./server/static", recursive=True
-        ).load_data()
-        VectorStoreIndex.from_documents(docs)
-
-    except APIConnectionError:
+        # GET /v1/models 에 요청을 보내 모델 서버 상태를 확인함
+        requests.get(base_url + "/models", timeout=2)
+    except requests.exceptions.Timeout:
         logging.warning("모델 서버에 연결할 수 없음")
         return Pong(status=False)
 


### PR DESCRIPTION
/ping이
/v1/embeddings 호출하는 구조에서 (gpu 사용, 자원을 앞에서 사용 중이면 밀림)

/v1/models 호출하는 구조로 변경 (데이터 꺼내주기)