### PR TITLE
feat: /embed 출력 변경 (recap, dashboard, recommend)

### DIFF
--- a/server/models/dashboard.py
+++ b/server/models/dashboard.py
@@ -10,13 +10,13 @@ class DashboardType(str, Enum):
 
 
 class DashboardOutput(BaseModel):
-    title: str = Field(description="The title representing the visualization of the dashboard.")
     type: DashboardType = Field(
         description="""
         The type of data to be displayed on the dashboard. 
         Choose from DashboardType.LINE, DashboardType.PIE, DashboardType.BAR."""
     )
-    labels: List[int] = Field(
+    title: str = Field(description="The title representing the visualization of the dashboard.")
+    labels: List[str] = Field(
         description="List of labels for the dashboard, providing context to the displayed data."
     )
     data: List[int] = Field(

--- a/server/models/embed.py
+++ b/server/models/embed.py
@@ -1,0 +1,11 @@
+from typing import List, Optional
+from pydantic import BaseModel
+from .dashboard import DashboardOutput
+from .recap import RecapOutput
+
+
+class EmbedOutput(BaseModel):
+    status: bool
+    recap: Optional[RecapOutput]
+    recommendations: Optional[List[str]]  # RecommendationOutput
+    dashboards: Optional[List[DashboardOutput]]

--- a/server/models/generate.py
+++ b/server/models/generate.py
@@ -1,4 +1,12 @@
+from typing import Optional
+
+from enum import Enum
 from pydantic import BaseModel, Field
+
+
+class AnswerType(str, Enum):
+    TEXT = "TEXT"
+    DASHBOARD = "DASHBOARD"
 
 
 class Question(BaseModel):
@@ -6,9 +14,11 @@ class Question(BaseModel):
 
 
 class Answer(BaseModel):
+    type: Optional[AnswerType] = Field(description="AI 챗봇이 생성한 답변의 형식을 정의합니다. ")
     message: str = Field(description="사용자의 질문에 대응하는 AI 챗봇의 답변 텍스트입니다. ")
 
     def to_dict(self):
         return {
+            "type": self.type,
             "message": self.message,
         }

--- a/server/models/recap.py
+++ b/server/models/recap.py
@@ -1,0 +1,26 @@
+from typing import List
+from pydantic import BaseModel, Field
+
+
+class RecapOutput(BaseModel):
+    title: str = Field(
+        description="A concise one-line summary that captures the main topic of the document."
+    )
+    subtitle: str = Field(
+        description="Additional information below the title, providing specifying subtopics."
+    )
+    summary: str = Field(
+        description="A brief overview encapsulating the main content of the document."
+    )
+    keywords: List[str] = Field(
+        description="List of frequently used important WORDs or terms in the document.",
+        max_items=3,
+    )
+
+    def to_dict(self):
+        return {
+            "title": self.title,
+            "subtitle": self.subtitle,
+            "summary": self.summary,
+            "keywords": self.keywords,
+        }

--- a/server/models/recommendation.py
+++ b/server/models/recommendation.py
@@ -3,7 +3,21 @@ from pydantic import BaseModel, Field
 
 
 class RecommendationOutput(BaseModel):
-    recommendations: List[str] = Field(description="Recommended questions for users to ask")
+    recommendations: List[str] = Field(
+        description="Recommended questions for users to ask",
+        min_items=3,
+    )
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "recommendations": [
+                    "2023 하반기에 주목해야 할 소매업계 이슈는 무엇인가요?",
+                    "디지털, 비용관리, 생성형 AI, PB, 불확실성 대응 체력을 키우기 위한 대응책은 무엇인가요?",
+                    "소매업계 데이터를 통해 어떤 정보를 얻을 수 있나요?",
+                ]
+            }
+        }
 
     def to_dict(self):
         return {

--- a/server/models/recommendation.py
+++ b/server/models/recommendation.py
@@ -3,11 +3,9 @@ from pydantic import BaseModel, Field
 
 
 class RecommendationOutput(BaseModel):
-    status: bool = True
     recommendations: List[str] = Field(description="Recommended questions for users to ask")
 
     def to_dict(self):
         return {
-            "status": self.status,
             "recommendations": self.recommendations,
         }

--- a/server/routes/embed.py
+++ b/server/routes/embed.py
@@ -4,12 +4,15 @@ from ..services.embed import embed_file, generate_recommendations
 from ..services.session import set_user_id
 
 from ..models.recommendation import RecommendationOutput
+from ..models.embed import EmbedOutput
+from ..models.recap import RecapOutput
+from ..models.dashboard import DashboardType, DashboardOutput
 
 embed_router = APIRouter()
 
 
 @embed_router.get("/embed")
-async def embed(request: Request) -> RecommendationOutput:
+async def embed(request: Request) -> EmbedOutput:
     """
     인덱스를 모델 서버가 이해할 수 있는 형태로 임베딩합니다.
     """
@@ -18,7 +21,29 @@ async def embed(request: Request) -> RecommendationOutput:
     status = await embed_file()
 
     if status is False:
-        return RecommendationOutput(status=False)
+        result = EmbedOutput(status=False, recap=None, recommendations=None, dashboards=None)
+        return result
 
-    recommendations = await generate_recommendations()
-    return recommendations
+    recap_example = RecapOutput(
+        title="Document Title",
+        subtitle="Additional information or subtopics",
+        summary="Brief overview of the main content",
+        keywords=["keyword1", "keyword2", "keyword3"],
+    )
+    dashboards_example = [
+        DashboardOutput(
+            type=DashboardType.LINE,
+            title="Product Trends by Month",
+            labels=["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep"],
+            data=[10, 41, 35, 51, 49, 62, 69, 91, 148],
+        ),
+    ]
+    answer = await generate_recommendations()
+
+    result = EmbedOutput(
+        status=True,
+        recap=recap_example,
+        recommendations=answer.recommendations,
+        dashboards=dashboards_example,
+    )
+    return result

--- a/server/routes/generate.py
+++ b/server/routes/generate.py
@@ -15,5 +15,5 @@ async def generate(request: Request, question: Question) -> Answer:
     """
 
     set_user_id(request=request)
-    answer = await generate_message(question)
+    answer = await generate_message(question.message)
     return answer

--- a/server/services/agents/recap_agent.py
+++ b/server/services/agents/recap_agent.py
@@ -1,0 +1,37 @@
+from langchain.prompts import PromptTemplate
+from langchain.chat_models import ChatOpenAI
+from langchain.chains import LLMChain, RetrievalQAWithSourcesChain
+from langchain.chains.summarize import load_summarize_chain
+
+from ..output_parsers.output_parsers import RecapOutput, recap_parser
+
+
+def lookup(description: str) -> RecapOutput:
+    """
+    주어진 description을 기반으로 사용자가 물어볼 만한 적절한 질문을 생성하는 Agent
+    """
+    llm = ChatOpenAI(temperature=0.6, model_name="gpt-3.5-turbo")
+
+    recap_template = """
+    summarize the documents in Korean:
+    \n{format_instructions}
+    """
+
+    recap_prompt_template = PromptTemplate(
+        template=recap_template,
+        partial_variables={
+            "format_instructions": recap_parser.get_format_instructions(),
+        },
+    )
+
+    chain = RetrievalQAWithSourcesChain(
+        llm=llm,
+        prompt=recap_prompt_template,
+        retriever=None,
+        verbose=True,
+    )
+    raise NotImplementedError
+    
+    result = chain.run(description=description)
+
+    return recap_parser.parse(result)

--- a/server/services/agents/recommendation_agent.py
+++ b/server/services/agents/recommendation_agent.py
@@ -13,7 +13,7 @@ def lookup(description: str) -> RecommendationOutput:
 
     recommendation_template = """
     Given the description {description}
-    about a dataframe from create THREE specific questions that retailers might want to know about their data in Korean:
+    about a document or dataframe from create THREE specific questions that retailers might want to know about their data in Korean:
     Strictly follow the question format with question marks.
     \n{format_instructions}
     """

--- a/server/services/agents/recommendation_agent.py
+++ b/server/services/agents/recommendation_agent.py
@@ -9,11 +9,11 @@ def lookup(description: str) -> RecommendationOutput:
     """
     주어진 description을 기반으로 사용자가 물어볼 만한 적절한 질문을 생성하는 Agent
     """
-    llm = ChatOpenAI(temperature=0.6, model_name="gpt-3.5-turbo")
+    llm = ChatOpenAI(temperature=0.3, model_name="gpt-3.5-turbo")
 
     recommendation_template = """
     Given the description {description}
-    about a document or dataframe from create THREE specific questions that retailers might want to know about their data in Korean:
+    about a document from create THREE different specific questions that retailers might want to know about their data in Korean:
     Strictly follow the question format with question marks.
     \n{format_instructions}
     """

--- a/server/services/embed.py
+++ b/server/services/embed.py
@@ -65,6 +65,7 @@ async def generate_recommendations() -> RecommendationOutput:
     """
     answer = await generate_message(question_message=message)
     description = answer.message
+
     logging.info("description text: \n%s", description)
 
     result = recommendation_agent(description=description)

--- a/server/services/embed.py
+++ b/server/services/embed.py
@@ -12,6 +12,7 @@ from .ping import check_server_status
 from .storage import get_storage_path, load_table_filename
 from .agents.recommendation_agent import lookup as recommendation_agent
 from ..models.recommendation import RecommendationOutput
+from .generate import generate_message
 
 
 async def embed_file() -> bool:
@@ -59,12 +60,12 @@ async def generate_recommendations() -> RecommendationOutput:
     사용자가 물어볼 만한 적절한 질문을 파일 내용을 기반으로 생성합니다.
     """
 
-    # TODO: 업로드 파일에 대한 간략한 설명을 description으로 생성해낼 것
-
-    description = """
-    The data is a pandas dataframe with 112,191 entries 
-    and 18 columns representing various attributes of items in a store.
+    message = """
+    주어진 문서에 대응하는 title, subtitle, description을 각각 작성해줘.
     """
+    answer = await generate_message(question_message=message)
+    description = answer.message
+    logging.info("description text: \n%s", description)
 
     result = recommendation_agent(description=description)
 

--- a/server/services/generate.py
+++ b/server/services/generate.py
@@ -43,6 +43,7 @@ async def generate_message_from_table(question: Question, pandas_dataframe_filen
     agent = create_pandas_dataframe_agent(
         llm=llm,
         df=df,
+        verbose=True,
         return_intermediate_steps=True,
         handle_parsing_errors=True,
     )

--- a/server/services/generate.py
+++ b/server/services/generate.py
@@ -38,12 +38,13 @@ async def generate_message(question: Question) -> Answer:
 async def generate_message_from_table(question: Question, pandas_dataframe_filename: str) -> Answer:
     df = pd.read_csv(pandas_dataframe_filename)
 
-    llm = ChatOpenAI(temperature=0.6)
+    llm = ChatOpenAI(temperature=0.6, model="gpt-4")
+
     agent = create_pandas_dataframe_agent(
         llm=llm,
         df=df,
-        verbose=False,
         return_intermediate_steps=True,
+        handle_parsing_errors=True,
     )
 
     logging.info("pandas dataframe agent 호출")
@@ -64,7 +65,6 @@ async def generate_message_from_document(question: Question) -> Answer:
     try:
         logging.info("query engine 호출")
         query_engine = index.as_query_engine()
-        question.message = f"메타 데이터를 제외하고 대답해줘. {question.message}"
         res = query_engine.query(question.message)
         message = res.response
 

--- a/server/services/generate.py
+++ b/server/services/generate.py
@@ -10,7 +10,7 @@ from langchain.chat_models import ChatOpenAI
 from langchain_experimental.agents import create_pandas_dataframe_agent
 from openai import APIConnectionError
 
-from ..models.generate import Answer
+from ..models.generate import Answer, AnswerType
 from .storage import load_embed_index, load_table_filename
 
 
@@ -54,7 +54,10 @@ async def generate_message_from_table(
     logging.info("pandas dataframe agent 호출")
 
     response = agent.invoke({"input": question_message})
-    answer = Answer(message=response["output"])
+    answer = Answer(
+        type=AnswerType.TEXT,
+        message=response["output"],
+    )
     return answer
 
 
@@ -64,7 +67,10 @@ async def generate_message_from_document(question_message: str) -> Answer:
     index = await load_embed_index()
     if index is None:
         message = "파일이 첨부되지 않았습니다."
-        return Answer(message=message)
+        return Answer(
+            type=AnswerType.TEXT,
+            message=message,
+        )
 
     try:
         logging.info("query engine 호출")
@@ -76,4 +82,7 @@ async def generate_message_from_document(question_message: str) -> Answer:
         logging.warning("모델 서버에 연결할 수 없음")
         message = "모델 서버 상태를 확인해주세요."
 
-    return Answer(message=message)
+    return Answer(
+        type=AnswerType.TEXT,
+        message=message,
+    )

--- a/server/services/output_parsers/output_parsers.py
+++ b/server/services/output_parsers/output_parsers.py
@@ -2,6 +2,7 @@ from langchain.output_parsers import PydanticOutputParser
 
 from ...models.dashboard import DashboardOutput
 from ...models.recommendation import RecommendationOutput
+from ...models.recap import RecapOutput
 
 dashboard_parser: PydanticOutputParser[DashboardOutput] = PydanticOutputParser(
     pydantic_object=DashboardOutput
@@ -9,3 +10,4 @@ dashboard_parser: PydanticOutputParser[DashboardOutput] = PydanticOutputParser(
 recommendation_parser: PydanticOutputParser[RecommendationOutput] = PydanticOutputParser(
     pydantic_object=RecommendationOutput
 )
+recap_parser: PydanticOutputParser[RecapOutput] = PydanticOutputParser(pydantic_object=RecapOutput)

--- a/server/services/ping.py
+++ b/server/services/ping.py
@@ -16,7 +16,6 @@ async def check_server_status() -> bool:
     # 작업 시작
     api_base = os.getenv("OPENAI_API_BASE")
     openai_api_key = os.getenv("OPENAI_API_KEY")
-    organization_id = os.getenv("OPENAI_ORGANIZATION_ID")
 
     if api_base is None:
         api_base = "https://api.openai.com/v1"
@@ -25,6 +24,7 @@ async def check_server_status() -> bool:
         "Authorization": f"Bearer {openai_api_key}",
     }
     url = api_base + "/models"
+
 
     try:
         response = requests.get(url, headers=headers, timeout=2)

--- a/server/services/ping.py
+++ b/server/services/ping.py
@@ -23,7 +23,6 @@ async def check_server_status() -> bool:
 
     headers = {
         "Authorization": f"Bearer {openai_api_key}",
-        "OpenAI-Organization": organization_id,
     }
     url = api_base + "/models"
 


### PR DESCRIPTION
GET /embed 요청하면
```json
{
    "status": true,
    "recap": {
        "title": "Document Title",
        "subtitle": "Additional information or subtopics",
        "summary": "Brief overview of the main content",
        "keywords": [
            "keyword1",
            "keyword2",
            "keyword3"
        ]
    },
    "recommendations": [
        "소매업 이슈에 대한 데이터 분석 결과는 무엇인가요?",
        "세부 동작과 개발 진행에 관한 정보는 어떻게 확인할 수 있나요?",
        "프론트엔드와 웹 서버에 대한 코드 리뷰와 구현 과제는 어떤 내용을 포함하고 있나요?"
    ],
    "dashboards": [
        {
            "type": "LINE",
            "title": "Product Trends by Month",
            "labels": [
                "Jan",
                "Feb",
                "Mar",
                "Apr",
                "May",
                "Jun",
                "Jul",
                "Aug",
                "Sep"
            ],
            "data": [
                10,
                41,
                35,
                51,
                49,
                62,
                69,
                91,
                148
            ]
        }
    ]
}
```
처럼 반환 옵니다.

\+ agent 초석 다져놨음