### PR TITLE
feat: Agent 작업 외

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -2,14 +2,14 @@ import logging
 import os
 
 from dotenv import load_dotenv
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from .routes.embed import embed_router
 from .routes.generate import generate_router
 from .routes.ping import ping_router
 from .routes.upload import upload_router
-
+from .services.session import set_user_id
 
 app = FastAPI()
 
@@ -27,6 +27,16 @@ app.include_router(ping_router)
 app.include_router(upload_router)
 app.include_router(embed_router)
 app.include_router(generate_router)
+
+
+@app.middleware("http")
+async def add_user_id_to_request(request: Request, call_next):
+    """
+    모든 요청에 대해 사용자 ID를 추가합니다.
+    """
+    set_user_id(request)
+    response = await call_next(request)
+    return response
 
 
 @app.on_event("startup")

--- a/server/routes/embed.py
+++ b/server/routes/embed.py
@@ -1,9 +1,7 @@
 from fastapi import APIRouter
 
-from ..services.embed import embed_document, generate_recommendations
+from ..services.embed import run
 from ..models.embed import EmbedOutput
-from ..models.recap import RecapOutput
-from ..models.chart import ChartOutput, ChartType, Series
 
 embed_router = APIRouter()
 
@@ -14,37 +12,4 @@ async def embed() -> EmbedOutput:
     인덱스를 모델 서버가 이해할 수 있는 형태로 임베딩합니다.
     """
 
-    status = embed_document()
-
-    if status is False:
-        result = EmbedOutput(status=False, recap=None, recommendations=None, chart=None)
-        return result
-
-    recap_example = RecapOutput(
-        title="Document Title",
-        subtitle="Additional information or subtopics",
-        summary="Brief overview of the main content",
-        keywords=["keyword1", "keyword2", "keyword3"],
-    )
-    charts_example = [
-        ChartOutput(
-            type=ChartType.LINE,
-            title="Product Trends by Month",
-            labels=["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep"],
-            series=[
-                Series(
-                    name="Product A",
-                    data=[10, 41, 35, 51, 49, 62, 69, 91, 148],
-                )
-            ],
-        ),
-    ]
-    answer = generate_recommendations()
-
-    result = EmbedOutput(
-        status=True,
-        recap=recap_example,
-        recommendations=answer.recommendations,
-        charts=charts_example,
-    )
-    return result
+    return run()

--- a/server/routes/embed.py
+++ b/server/routes/embed.py
@@ -17,7 +17,7 @@ async def embed(request: Request) -> EmbedOutput:
     """
 
     set_user_id(request=request)
-    status = await embed_file()
+    status = embed_file()
 
     if status is False:
         result = EmbedOutput(status=False, recap=None, recommendations=None, chart=None)
@@ -42,7 +42,7 @@ async def embed(request: Request) -> EmbedOutput:
             ],
         ),
     ]
-    answer = await generate_recommendations()
+    answer = generate_recommendations()
 
     result = EmbedOutput(
         status=True,

--- a/server/routes/embed.py
+++ b/server/routes/embed.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from ..services.embed import embed_file, generate_recommendations
+from ..services.embed import embed_document, generate_recommendations
 from ..models.embed import EmbedOutput
 from ..models.recap import RecapOutput
 from ..models.chart import ChartOutput, ChartType, Series
@@ -14,7 +14,7 @@ async def embed() -> EmbedOutput:
     인덱스를 모델 서버가 이해할 수 있는 형태로 임베딩합니다.
     """
 
-    status = embed_file()
+    status = embed_document()
 
     if status is False:
         result = EmbedOutput(status=False, recap=None, recommendations=None, chart=None)

--- a/server/routes/embed.py
+++ b/server/routes/embed.py
@@ -1,8 +1,6 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 
 from ..services.embed import embed_file, generate_recommendations
-from ..services.session import set_user_id
-
 from ..models.embed import EmbedOutput
 from ..models.recap import RecapOutput
 from ..models.chart import ChartOutput, ChartType, Series
@@ -11,12 +9,11 @@ embed_router = APIRouter()
 
 
 @embed_router.get("/embed")
-async def embed(request: Request) -> EmbedOutput:
+async def embed() -> EmbedOutput:
     """
     인덱스를 모델 서버가 이해할 수 있는 형태로 임베딩합니다.
     """
 
-    set_user_id(request=request)
     status = embed_file()
 
     if status is False:

--- a/server/routes/generate.py
+++ b/server/routes/generate.py
@@ -15,5 +15,5 @@ async def generate(request: Request, question: Question) -> Answer:
     """
 
     set_user_id(request=request)
-    answer = await generate_message(question.message)
+    answer = generate_message(question.message)
     return answer

--- a/server/routes/generate.py
+++ b/server/routes/generate.py
@@ -1,19 +1,17 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 
 from ..models.generate import Answer, Question
 from ..services.generate import generate_message
-from ..services.session import set_user_id
 
 
 generate_router = APIRouter()
 
 
 @generate_router.post("/generate")
-async def generate(request: Request, question: Question) -> Answer:
+async def generate(question: Question) -> Answer:
     """
     메시지를 생성합니다.
     """
 
-    set_user_id(request=request)
     answer = generate_message(question.message)
     return answer

--- a/server/routes/ping.py
+++ b/server/routes/ping.py
@@ -9,5 +9,5 @@ ping_router = APIRouter()
 
 @ping_router.get("/ping")
 async def ping() -> Pong:
-    status = await check_server_status()
+    status = check_server_status()
     return Pong(status=status)

--- a/server/routes/upload.py
+++ b/server/routes/upload.py
@@ -18,4 +18,4 @@ async def upload(request: Request, file: UploadFile = Form(...), description: st
     contents = await file.read()
     filename = file.filename.replace(" ", "-")
 
-    return await upload_file(contents, filename, description)
+    return upload_file(contents, filename, description)

--- a/server/routes/upload.py
+++ b/server/routes/upload.py
@@ -14,5 +14,6 @@ async def upload(file: UploadFile = Form(...), description: str = Form(...)):
 
     contents = await file.read()
     filename = file.filename.replace(" ", "-")
+    description = description.replace(" ", "-")
 
     return upload_file(contents, filename, description)

--- a/server/routes/upload.py
+++ b/server/routes/upload.py
@@ -1,6 +1,5 @@
-from fastapi import APIRouter, Form, Request, UploadFile
+from fastapi import APIRouter, Form, UploadFile
 
-from ..services.session import set_user_id
 from ..services.upload import upload_file
 
 
@@ -8,12 +7,10 @@ upload_router = APIRouter()
 
 
 @upload_router.post("/upload")
-async def upload(request: Request, file: UploadFile = Form(...), description: str = Form(...)):
+async def upload(file: UploadFile = Form(...), description: str = Form(...)):
     """
     인덱스로 사용할 파일을 업로드합니다.
     """
-
-    set_user_id(request=request)
 
     contents = await file.read()
     filename = file.filename.replace(" ", "-")

--- a/server/services/agents/dashboard_parsing_agent.py
+++ b/server/services/agents/dashboard_parsing_agent.py
@@ -1,4 +1,4 @@
-from langchain.chat_models.openai import ChatOpenAI
+from langchain_openai.chat_models import ChatOpenAI
 from langchain_experimental.agents import create_pandas_dataframe_agent
 from pandas import DataFrame
 

--- a/server/services/agents/recap_agent.py
+++ b/server/services/agents/recap_agent.py
@@ -1,36 +1,56 @@
-from langchain.prompts import PromptTemplate
-from langchain.chains import RetrievalQAWithSourcesChain
+from operator import itemgetter
+from langchain_core.prompts import PromptTemplate
 from langchain_openai.chat_models import ChatOpenAI
-
+from langchain.callbacks.tracers import ConsoleCallbackHandler
+from ..storage import load_vectorstore
 from ..output_parsers.output_parsers import RecapOutput, recap_parser
 
+RECAP_TEMPLATE = """Organize the title, flow, and main keywords of the document.
+Answer in the language Korean. Context is below: 
+```
+{context}
+```
+\n{format_instructions}"""
 
-def lookup(description: str) -> RecapOutput:
-    """
-    주어진 description을 기반으로 사용자가 물어볼 만한 적절한 질문을 생성하는 Agent
-    """
-    llm = ChatOpenAI(temperature=0.6, model_name="gpt-3.5-turbo")
 
-    recap_template = """
-    summarize the documents in Korean:
-    \n{format_instructions}
+def lookup() -> RecapOutput:
     """
+    임베딩한 문서를 기반으로 요약 문서를 생성하는 Agent
 
-    recap_prompt_template = PromptTemplate(
-        template=recap_template,
-        partial_variables={
-            "format_instructions": recap_parser.get_format_instructions(),
-        },
+    # 문제 1. 문서를 제대로 못 물어옴 ㅠ 용량이 작으면 통째로 첨부할 예정
+    아래 링크로 리팩터링 예정
+    see more at :
+    https://python.langchain.com/docs/modules/data_connection/retrievers/multi_vector#summary
+    """
+    llm = ChatOpenAI(temperature=0.2, model_name="gpt-3.5-turbo")
+
+    vectorstore = load_vectorstore()
+    retriever = vectorstore.as_retriever(search_type="similarity", search_kwargs={"k": 3})
+
+    rag_prompt = PromptTemplate(
+        template=RECAP_TEMPLATE,
+        input_variables=["context"],
+        partial_variables={"format_instructions": recap_parser.get_format_instructions()},
     )
 
-    chain = RetrievalQAWithSourcesChain(
-        llm=llm,
-        prompt=recap_prompt_template,
-        retriever=None,
-        verbose=True,
+    def format_docs(docs):
+        return "\n\n".join(doc.page_content for doc in docs)
+
+    question = "Organize the title, flow, and main keywords of the document."
+
+    # LCEL 정의
+    rag_chain = (
+        {
+            "context": itemgetter("question") | retriever | format_docs,
+        }
+        | rag_prompt
+        | llm
+        | recap_parser
     )
-    raise NotImplementedError
 
-    result = chain.run(description=description)
+    recap_output = rag_chain.invoke(
+        {"question": question},
+        config={"callbacks": [ConsoleCallbackHandler()]},
+    )
 
-    return recap_parser.parse(result)
+    return recap_output

--- a/server/services/agents/recap_agent.py
+++ b/server/services/agents/recap_agent.py
@@ -1,7 +1,6 @@
 from langchain.prompts import PromptTemplate
-from langchain.chat_models.openai import ChatOpenAI
 from langchain.chains import RetrievalQAWithSourcesChain
-from langchain.chains.summarize import load_summarize_chain
+from langchain_openai.chat_models import ChatOpenAI
 
 from ..output_parsers.output_parsers import RecapOutput, recap_parser
 

--- a/server/services/agents/recommendation_agent.py
+++ b/server/services/agents/recommendation_agent.py
@@ -18,8 +18,6 @@ def lookup(description: str) -> RecommendationOutput:
     \n{format_instructions}
     """
 
-    # TODO: FewShotPromptTemplate 로 바꿀 것
-
     recommendation_prompt_template = PromptTemplate(
         input_variables=["description"],
         template=recommendation_template,

--- a/server/services/agents/recommendation_agent.py
+++ b/server/services/agents/recommendation_agent.py
@@ -1,5 +1,5 @@
 from langchain.prompts import PromptTemplate
-from langchain.chat_models.openai import ChatOpenAI
+from langchain_openai.chat_models import ChatOpenAI
 from langchain.chains import LLMChain
 
 from ..output_parsers.output_parsers import RecommendationOutput, recommendation_parser

--- a/server/services/agents/recommendation_agent.py
+++ b/server/services/agents/recommendation_agent.py
@@ -1,36 +1,44 @@
-from langchain.prompts import PromptTemplate
+from operator import itemgetter
+import json
+from langchain_core.prompts import PromptTemplate
 from langchain_openai.chat_models import ChatOpenAI
-from langchain.chains import LLMChain
+from langchain.callbacks.tracers import ConsoleCallbackHandler
+from ..output_parsers.output_parsers import RecapOutput, RecommendationOutput, recommendation_parser
 
-from ..output_parsers.output_parsers import RecommendationOutput, recommendation_parser
+
+RECOMMENDATION_TEMPLATE = """Given the recap of the data {racap}
+about a document from create THREE different specific questions that retailers might want to know about their data in Korean:
+\n{format_instructions}"""
 
 
-def lookup(description: str) -> RecommendationOutput:
+def lookup(recap_output: RecapOutput) -> RecommendationOutput:
     """
-    주어진 description을 기반으로 사용자가 물어볼 만한 적절한 질문을 생성하는 Agent
+    임베딩 정보를 기반으로 사용자가 물어볼 만한 적절한 질문을 생성하는 Agent
     """
-    llm = ChatOpenAI(temperature=0.3, model_name="gpt-3.5-turbo")
+    recap = json.dumps(recap_output.to_dict())
+    llm = ChatOpenAI(temperature=0.4, model_name="gpt-3.5-turbo")
 
-    recommendation_template = """
-    Given the description {description}
-    about a document from create THREE different specific questions that retailers might want to know about their data in Korean:
-    Strictly follow the question format with question marks.
-    \n{format_instructions}
-    """
-
-    recommendation_prompt_template = PromptTemplate(
-        input_variables=["description"],
-        template=recommendation_template,
+    rag_prompt = PromptTemplate(
+        input_variables=["racap"],
+        template=RECOMMENDATION_TEMPLATE,
         partial_variables={
             "format_instructions": recommendation_parser.get_format_instructions(),
         },
     )
 
-    chain = LLMChain(
-        llm=llm,
-        prompt=recommendation_prompt_template,
+    # LCEL 정의
+    rag_chain = (
+        {
+            "racap": itemgetter("racap"),
+        }
+        | rag_prompt
+        | llm
+        | recommendation_parser
     )
 
-    result = chain.run(description=description)
+    recommendation_output = rag_chain.invoke(
+        {"racap": recap},
+        config={"callbacks": [ConsoleCallbackHandler()]},
+    )
 
-    return recommendation_parser.parse(result)
+    return recommendation_output

--- a/server/services/embed.py
+++ b/server/services/embed.py
@@ -4,10 +4,8 @@ GET /embed
 """
 
 import logging
-import os
 
 from openai import APIConnectionError
-
 from langchain_community.document_loaders import DirectoryLoader
 from langchain_community.vectorstores.chroma import Chroma
 from langchain_openai.embeddings import OpenAIEmbeddings
@@ -15,7 +13,7 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 
 from .ping import check_server_status
-from .storage import get_storage_path, load_table_filename
+from .storage import get_document_path, get_chroma_path, load_table_filename
 from .agents.recommendation_agent import lookup as recommendation_agent
 from ..models.recommendation import RecommendationOutput
 from .generate import generate_message
@@ -23,45 +21,49 @@ from .generate import generate_message
 
 def embed_file() -> bool:
     """
-    저장소에 있는 파일을 모델 서버로 보내 임베딩 결과(bool)를 받아옴
+    저장소에 있는 파일을 모델 서버로 보내 임베딩 결과를 받아옵니다.
     """
-    storage_path = get_storage_path()
-    document_path = os.path.join(storage_path, "document")
-    chroma_path = os.path.join(storage_path, "chroma")
-    table_filename = load_table_filename()
-
-    if table_filename is not None:
-        logging.info("테이블 파일은 임베딩하지 않음")
-        return True
 
     # 모델 서버가 불안정하면 임베딩을 진행하지 않음
     if check_server_status() is False:
         return False
 
+    # 테이블 파일은 임베딩하지 않음
+    if load_table_filename() is not None:
+        logging.info("테이블 파일은 임베딩하지 않음")
+        return True
+
+    # 문서 파일 임베딩
+    document_path = get_document_path()
+    chroma_path = get_chroma_path()
+
     try:
-        # 디렉토리를 읽어옵니다.
+        # 디렉토리를 읽어옵니다. [UnstructuredFileLoader]
         loader = DirectoryLoader(document_path, show_progress=True)
         documents = loader.load()
 
     except ValueError:
-        logging.warning("임베딩 실패: 저장소가 비어 있음")
+        logging.warning("문서 임베딩 오류: 저장소를 읽을 수 없음")
         return False
 
-    text_splitter = RecursiveCharacterTextSplitter(
-        chunk_size=1000, chunk_overlap=200, add_start_index=True
-    )
     # split documents
+    text_splitter = RecursiveCharacterTextSplitter(
+        chunk_size=500,
+        chunk_overlap=100,
+        add_start_index=True,
+    )
     splitted_documents = text_splitter.split_documents(documents)
 
     try:
+        # persist documents
         Chroma.from_documents(
             documents=splitted_documents,
             persist_directory=chroma_path,
             embedding=OpenAIEmbeddings(),
         )
 
-    except APIConnectionError:
-        logging.warning("모델 서버에 연결할 수 없음")
+    except ValueError:
+        logging.warning("문서 임베딩 오류: 모델 서버에 연결할 수 없음")
         return False
     return True
 
@@ -76,8 +78,6 @@ def generate_recommendations() -> RecommendationOutput:
     """
     answer = generate_message(question_message=message)
     description = answer.message
-
-    logging.info("description text: \n%s", description)
 
     result = recommendation_agent(description=description)
 

--- a/server/services/embed.py
+++ b/server/services/embed.py
@@ -5,6 +5,7 @@ GET /embed
 
 import logging
 
+from pydantic import ValidationError
 from langchain_community.document_loaders import DirectoryLoader
 from langchain_community.vectorstores.chroma import Chroma
 from langchain_openai.embeddings import OpenAIEmbeddings
@@ -12,9 +13,83 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from .ping import check_server_status
 from .storage import get_document_path, get_chroma_path
+from .agents.recap_agent import lookup as recap_agent, RecapOutput
 from .agents.recommendation_agent import lookup as recommendation_agent
-from ..models.recommendation import RecommendationOutput
-from .generate import generate_message
+from ..models.embed import EmbedOutput
+from ..models.chart import ChartType, Series, ChartOutput
+
+
+def run() -> EmbedOutput:
+    # 모델 서버가 불안정하면 임베딩을 진행하지 않습니다.
+    if not check_server_status():
+        return EmbedOutput(status=False)
+
+    # 첨부한 파일 또는 문서를 임베딩합니다.
+    if not embed_document():
+        return EmbedOutput(status=False)
+
+    recap: RecapOutput = None
+    recommendations: list[str] = None
+    charts: ChartOutput = None
+
+    error_iter = 0
+    max_error_iter = 5
+
+    while error_iter < max_error_iter:
+        try:
+            # LLM으로부터 recap을 생성합니다.
+            if not recap:
+                recap = recap_agent()
+                logging.info("생성한 recap: %s, ...", recap.summary)
+
+            # LLM으로부터 list of recommendation을 생성합니다.
+            if not recommendations:
+                recommendation_output = recommendation_agent(recap_output=recap)
+                recommendations = recommendation_output.recommendations
+                logging.info("생성한 recommendations: %s, ...", recommendations[0])
+
+            # list of chart를 생성합니다. (현재 example)
+            if not charts:
+                charts = [
+                    ChartOutput(
+                        type=ChartType.LINE,
+                        title="Product Trends by Month",
+                        labels=["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep"],
+                        series=[
+                            Series(
+                                name="Product A",
+                                data=[10, 41, 35, 51, 49, 62, 69, 91, 148],
+                            )
+                        ],
+                    ),
+                ]
+                logging.info("생성한 charts: %s, ...", charts)
+
+            # 에러 없이 모두 성공했으므로 루프를 종료합니다.
+            break
+
+        except ValidationError as err:
+            error_iter += 1
+            logging.warning("Pydantic ValidationError iteration. [%s]", error_iter)
+
+            # 최대 에러 횟수를 초과하면 함수를 종료합니다.
+            if error_iter >= max_error_iter:
+                logging.warning("Pydantic ValidationError max iteration exceeded. \n%s", err)
+
+                return EmbedOutput(
+                    status=False,
+                    recap=recap,
+                    recommendations=recommendations,
+                    charts=charts,
+                )
+
+    result = EmbedOutput(
+        status=True,
+        recap=recap,
+        recommendations=recommendations,
+        charts=charts,
+    )
+    return result
 
 
 def embed_document() -> bool:
@@ -22,16 +97,12 @@ def embed_document() -> bool:
     저장소에 있는 파일을 모델 서버로 보내 임베딩 결과를 받아옵니다.
     """
 
-    # 모델 서버가 불안정하면 임베딩을 진행하지 않음
-    if check_server_status() is False:
-        return False
-
     # 문서 파일 임베딩
     document_path = get_document_path()
     chroma_path = get_chroma_path()
 
     try:
-        # 디렉토리를 읽어옵니다. [UnstructuredFileLoader]
+        # 디렉토리를 읽어옵니다. [Loader: UnstructuredFileLoader]
         loader = DirectoryLoader(document_path, show_progress=True)
         documents = loader.load()
 
@@ -39,39 +110,24 @@ def embed_document() -> bool:
         logging.warning("문서 임베딩 오류: 저장소를 읽을 수 없음")
         return False
 
-    # split documents
+    # 문서를 text_splitter로 자릅니다.
     text_splitter = RecursiveCharacterTextSplitter(
-        chunk_size=500,
-        chunk_overlap=100,
+        chunk_size=1000,
+        chunk_overlap=200,
         add_start_index=True,
     )
     splitted_documents = text_splitter.split_documents(documents)
-
     try:
-        # persist documents
-        Chroma.from_documents(
+        # 자른 문서를 persist 합니다.
+        vectorstore = Chroma.from_documents(
             documents=splitted_documents,
             persist_directory=chroma_path,
             embedding=OpenAIEmbeddings(),
         )
+        vectorstore.persist()
 
     except ValueError:
         logging.warning("문서 임베딩 오류: 모델 서버에 연결할 수 없음")
         return False
+
     return True
-
-
-def generate_recommendations() -> RecommendationOutput:
-    """
-    사용자가 물어볼 만한 적절한 질문을 파일 내용을 기반으로 생성합니다.
-    """
-
-    message = """
-    주어진 문서에 대응하는 title, subtitle, description을 각각 작성해줘.
-    """
-    answer = generate_message(question_message=message)
-    description = answer.message
-
-    result = recommendation_agent(description=description)
-
-    return result

--- a/server/services/embed.py
+++ b/server/services/embed.py
@@ -5,21 +5,19 @@ GET /embed
 
 import logging
 
-from openai import APIConnectionError
 from langchain_community.document_loaders import DirectoryLoader
 from langchain_community.vectorstores.chroma import Chroma
 from langchain_openai.embeddings import OpenAIEmbeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
-
 from .ping import check_server_status
-from .storage import get_document_path, get_chroma_path, load_table_filename
+from .storage import get_document_path, get_chroma_path
 from .agents.recommendation_agent import lookup as recommendation_agent
 from ..models.recommendation import RecommendationOutput
 from .generate import generate_message
 
 
-def embed_file() -> bool:
+def embed_document() -> bool:
     """
     저장소에 있는 파일을 모델 서버로 보내 임베딩 결과를 받아옵니다.
     """
@@ -27,11 +25,6 @@ def embed_file() -> bool:
     # 모델 서버가 불안정하면 임베딩을 진행하지 않음
     if check_server_status() is False:
         return False
-
-    # 테이블 파일은 임베딩하지 않음
-    if load_table_filename() is not None:
-        logging.info("테이블 파일은 임베딩하지 않음")
-        return True
 
     # 문서 파일 임베딩
     document_path = get_document_path()

--- a/server/services/generate.py
+++ b/server/services/generate.py
@@ -7,41 +7,39 @@ import logging
 from operator import itemgetter
 
 import pandas as pd
-from langchain.chat_models.openai import ChatOpenAI
+from langchain_openai.chat_models import ChatOpenAI
 from langchain_core.prompts import PromptTemplate
 from langchain_core.output_parsers import StrOutputParser
 from langchain_experimental.agents import create_pandas_dataframe_agent
 from openai import APIConnectionError
 
 from ..models.generate import Answer, AnswerType
-from .storage import load_embed_index, load_table_filename
+from .storage import load_vectorstore, load_table_filename
 
 
-async def generate_message(question_message: str) -> Answer:
+def generate_message(question_message: str) -> Answer:
     """
     LLM에 질문을 전달해 답변을 생성합니다.
     """
     logging.info("요청한 질문: %s", question_message)
 
     answer = None
-    table_filename = await load_table_filename()
+    table_filename = load_table_filename()
 
     if table_filename is not None:
-        answer = await generate_message_from_table(
+        answer = generate_message_from_table(
             question_message=question_message,
-            pandas_dataframe_filename=table_filename,
+            df_filename=table_filename,
         )
     else:
-        answer = await generate_message_from_document(question_message=question_message)
+        answer = generate_message_from_document(question_message=question_message)
 
     logging.info("생성한 응답: %s", answer.message)
     return answer
 
 
-async def generate_message_from_table(
-    question_message: str, pandas_dataframe_filename: str
-) -> Answer:
-    df = pd.read_csv(pandas_dataframe_filename)
+def generate_message_from_table(question_message: str, df_filename: str) -> Answer:
+    df = pd.read_csv(df_filename)
 
     llm = ChatOpenAI(temperature=0.6, model="gpt-3.5-turbo")
 
@@ -50,13 +48,13 @@ async def generate_message_from_table(
         df=df,
         verbose=True,
         return_intermediate_steps=True,
-        handle_parsing_errors=True,
     )
-    agent.handle_parsing_errors = True
 
     logging.info("pandas dataframe agent 호출")
 
     response = agent.invoke({"input": question_message})
+    print(f"{response=}")
+
     answer = Answer(
         type=AnswerType.TEXT,
         message=response["output"],
@@ -64,13 +62,13 @@ async def generate_message_from_table(
     return answer
 
 
-async def generate_message_from_document(question_message: str) -> Answer:
+def generate_message_from_document(question_message: str) -> Answer:
     """
     문서로부터 답변을 생성합니다.
     """
     message = None
 
-    vectorstore = await load_embed_index()
+    vectorstore = load_vectorstore()
     if vectorstore is None:
         message = "파일이 첨부되지 않았습니다."
         return Answer(
@@ -84,10 +82,10 @@ async def generate_message_from_document(question_message: str) -> Answer:
         retriever = vectorstore.as_retriever(search_type="similarity", search_kwargs={"k": 3})
 
         # llm 정의
-        llm = ChatOpenAI(model_name="gpt-3.5-turbo", temperature=0)
+        llm = ChatOpenAI(model_name="gpt-3.5-turbo", temperature=0.2)
 
         # 템플릿 정의
-        template = """You are an assistant for question-answering tasks. 
+        template = """You are an assistant for question-answering tasks.
         Use the following pieces of retrieved context to answer the question. 
         If you don't know the answer, just say that you don't know. 
         Use three sentences maximum and keep the answer concise.
@@ -101,6 +99,7 @@ async def generate_message_from_document(question_message: str) -> Answer:
         custom_rag_prompt = PromptTemplate.from_template(template)
 
         def format_docs(docs):
+            # TODO: top-k docs를 클라이언트에게 전달할 것
             return "\n\n".join(doc.page_content for doc in docs)
 
         # LCEL 정의
@@ -117,7 +116,6 @@ async def generate_message_from_document(question_message: str) -> Answer:
 
         # 답변 생성
         message = rag_chain.invoke({"question": question_message, "language": "Korean"})
-
         logging.info("Answer: message")
         logging.info("RAG finished")
 

--- a/server/services/generate.py
+++ b/server/services/generate.py
@@ -96,7 +96,7 @@ def generate_message_from_document(question_message: str) -> Answer:
         custom_rag_prompt = PromptTemplate.from_template(template)
 
         def format_docs(docs):
-            # TODO: top-k docs를 클라이언트에게 전달할 것
+            # todo: top-k docs를 클라이언트에게 전달할 것
             return "\n\n".join(doc.page_content for doc in docs)
 
         # LCEL 정의

--- a/server/services/generate.py
+++ b/server/services/generate.py
@@ -14,7 +14,7 @@ from langchain_experimental.agents import create_pandas_dataframe_agent
 from openai import APIConnectionError
 
 from ..models.generate import Answer, AnswerType
-from .storage import load_vectorstore, load_table_filename
+from .storage import load_vectorstore, load_df_path
 
 
 def generate_message(question_message: str) -> Answer:
@@ -24,13 +24,10 @@ def generate_message(question_message: str) -> Answer:
     logging.info("요청한 질문: %s", question_message)
 
     answer = None
-    table_filename = load_table_filename()
+    df_path = load_df_path()
 
-    if table_filename is not None:
-        answer = generate_message_from_table(
-            question_message=question_message,
-            df_filename=table_filename,
-        )
+    if df_path:
+        answer = generate_message_from_table(question_message=question_message, df_path=df_path)
     else:
         answer = generate_message_from_document(question_message=question_message)
 
@@ -38,8 +35,8 @@ def generate_message(question_message: str) -> Answer:
     return answer
 
 
-def generate_message_from_table(question_message: str, df_filename: str) -> Answer:
-    df = pd.read_csv(df_filename)
+def generate_message_from_table(question_message: str, df_path: str) -> Answer:
+    df = pd.read_csv(df_path)
 
     llm = ChatOpenAI(temperature=0.6, model="gpt-3.5-turbo")
 

--- a/server/services/generate.py
+++ b/server/services/generate.py
@@ -69,7 +69,7 @@ def generate_message_from_document(question_message: str) -> Answer:
     message = None
 
     vectorstore = load_vectorstore()
-    if vectorstore is None:
+    if not vectorstore:
         message = "파일이 첨부되지 않았습니다."
         return Answer(
             type=AnswerType.TEXT,

--- a/server/services/ping.py
+++ b/server/services/ping.py
@@ -9,7 +9,7 @@ import os
 import requests
 
 
-async def check_server_status() -> bool:
+def check_server_status() -> bool:
     """
     모델 서버의 상태를 확인하는 함수
     """

--- a/server/services/ping.py
+++ b/server/services/ping.py
@@ -18,7 +18,7 @@ def check_server_status() -> bool:
     api_base = os.getenv("OPENAI_API_BASE")
     openai_api_key = os.getenv("OPENAI_API_KEY")
 
-    if api_base is None:
+    if not api_base:
         api_base = "https://api.openai.com/v1"
 
     headers = {

--- a/server/services/storage.py
+++ b/server/services/storage.py
@@ -97,9 +97,9 @@ def save_file(contents: bytes, filename: str, description: str) -> None:
         fp.write(contents)
 
 
-def load_table_filename() -> str | None:
+def load_df_path() -> str | None:
     """
-    path에 있는 첫 번째 테이블 파일 경로를 전달하는 함수
+    path에 있는 첫 번째 테이블 파일 경로를 전달하는 함수, 테이블 파일이 없다면 None을 반환합니다.
     """
     table_path = get_table_path()
     files_in_path = os.listdir(table_path)
@@ -127,5 +127,5 @@ def load_vectorstore() -> Chroma | None:
         return vectorstore
 
     except ValueError:  # 임베딩 파일이나 세션을 확인하지 못하는 경우
-        logging.warn("vectorstore를 가져오지 못함")
+        logging.warning("vectorstore를 가져오지 못함")
         return None

--- a/server/services/upload.py
+++ b/server/services/upload.py
@@ -38,16 +38,18 @@ def save_table_documentation(table_name: str, df_path: str):
     documentation = f"""
 # table documentation
 - This document is a description of the table file attached by the retailer to request analysis of his/her data.
-- NOTE: The original table name is '{table_name}', but a new name that matches the table information is needed. 
+- NOTE: The original title is '{table_name}', but a new name that matches the table information is needed. 
 
 ## information of dataframe
-- result of pd.DataFrame.info() is below:
+- Result of pd.DataFrame.info()
+- You can parse the necessary keywords by looking at them below.
 ```
 {df_info}
 ```
 
 ## Brief table contents
-- First 5 rows of the DataFrame is below:
+- First 5 rows of the DataFrame
+- can understand the flow of the document by looking below.
 ```
 {str(df.head())}
 ```

--- a/server/services/upload.py
+++ b/server/services/upload.py
@@ -2,8 +2,10 @@
 POST /upload 
 에 사용되는 비즈니스 로직을 담은 코드 페이지입니다. 
 """
+from io import StringIO
+from pandas import read_csv
 
-from .storage import clear_storage, save_file
+from .storage import clear_storage, save_file, load_df_path
 
 
 def upload_file(contents: bytes, filename: str, description: str) -> dict:
@@ -11,7 +13,45 @@ def upload_file(contents: bytes, filename: str, description: str) -> dict:
     클라이언트로부터 전달받은 파일을 웹 서버에 저장합니다
     """
 
+    # 저장소를 초기화하고 파일을 저장합니다.
     clear_storage()
     save_file(contents, filename, description)
 
+    # 테이블 데이터면 documentation을 추가로 생성합니다.
+    df_path = load_df_path()
+    if df_path:
+        save_table_documentation(table_name=description, df_path=df_path)
+
     return {"filename": filename, "description": description}
+
+
+def save_table_documentation(table_name: str, df_path: str):
+    """
+    테이블을 설명하는 documentation을 만들어 텍스트 문서로 저장합니다.
+    """
+    df = read_csv(df_path)
+
+    string_buffer = StringIO()
+    df.info(buf=string_buffer)
+    df_info = string_buffer.getvalue()
+
+    documentation = f"""
+# table documentation
+- This document is a description of the table file attached by the retailer to request analysis of his/her data.
+- NOTE: The original table name is '{table_name}', but a new name that matches the table information is needed. 
+
+## information of dataframe
+- result of pd.DataFrame.info() is below:
+```
+{df_info}
+```
+
+## Brief table contents
+- First 5 rows of the DataFrame is below:
+```
+{str(df.head())}
+```
+"""
+    contents = documentation.encode(encoding="utf-8")
+    description = f"{table_name}-documentation"
+    save_file(contents=contents, filename="docs.txt", description=description)

--- a/server/services/upload.py
+++ b/server/services/upload.py
@@ -6,12 +6,12 @@ POST /upload
 from .storage import clear_storage, save_file
 
 
-async def upload_file(contents: bytes, filename: str, description: str) -> dict:
+def upload_file(contents: bytes, filename: str, description: str) -> dict:
     """
     클라이언트로부터 전달받은 파일을 웹 서버에 저장합니다
     """
 
-    await clear_storage()
-    await save_file(contents, filename, description)
+    clear_storage()
+    save_file(contents, filename, description)
 
     return {"filename": filename, "description": description}

--- a/server/tests/test_main.py
+++ b/server/tests/test_main.py
@@ -6,7 +6,7 @@ from ..main import app
 # 테스트 함수는 "test_~" 로 이름을 지어야 합니다
 with TestClient(app) as client:
 
-    def test_모델_서버_상태_확인():
+    def test_ping():
         response = client.get("/ping")
         assert response.status_code == 200
         assert "status" in response.json()


### PR DESCRIPTION
작업하던 거 머지하면서 리팩터링 많이 했어요
### 파일 저장 디렉토리 구조 변경
```
storage
- raw
- embed
- structure 
```
에서

```
storage
- chroma
- document
- table
```
로 변경

### 비동기 구조 변경
- 함수에 붙어있던 async 깔끔하게 최소치만 남겨놨어요

### 세션 등록 미들웨어로 설정
- http 받으면 제일 먼저 set_user_id 하도록 변경
```python

@app.middleware("http")
async def add_user_id_to_request(request: Request, call_next):
    """
    모든 요청에 대해 사용자 ID를 추가합니다.
    """
    set_user_id(request)
    response = await call_next(request)
    return response
```

### 저장소 경로 함수화
```python
def get_storage_path() -> str:
def _get_subdirectory_path(subdirectory_name: str) -> str:
def get_document_path() -> str:
def get_table_path() -> str:
def get_chroma_path() -> str:
```

### 테이블 documentation 추가
- 테이블 데이터 들어오면 정적인 요약 파일 만들도록 코드 추가
- recap, recommend에 연계됨
- 내용이 조금 더 알찼으면 좋겠음!
```python
documentation = f"""
# table documentation
- This document is a description of the table file attached by the retailer to request analysis of his/her data.
- NOTE: The original title is '{table_name}', but a new name that matches the table information is needed. 

## information of dataframe
- Result of pd.DataFrame.info()
- You can parse the necessary keywords by looking at them below.
```
{df_info}
```

## Brief table contents
- First 5 rows of the DataFrame
- can understand the flow of the document by looking below.
```
{str(df.head())}
```
"""
```

### embed 구성 간소화
- 라우팅 페이지 로직을 run()으로 묶음
```python

@embed_router.get("/embed")
async def embed() -> EmbedOutput:
    """
    인덱스를 모델 서버가 이해할 수 있는 형태로 임베딩합니다.
    """

    return run()
```

### RecapAgent, RecommendationAgent 작업
- RecapAgent: 70% 완료
- RecommendationAgent: 95% 완료