### PR TITLE
refactor: 직접 dataframe 가져오는 방식으로 변경, document split 모듈화

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ pytest
 tabulate
 langchain
 langchain_experimental
-llama_index
 pypdf
 langchain-community 
 langchainhub 

--- a/server/models/recap.py
+++ b/server/models/recap.py
@@ -9,9 +9,7 @@ class RecapOutput(BaseModel):
     subtitle: str = Field(
         description="Additional information below the title, providing specifying subtopics."
     )
-    summary: str = Field(
-        description="A brief overview encapsulating the main content of the document."
-    )
+    summary: str = Field(description="final, consolidated summary of the main themes. ")
     keywords: List[str] = Field(
         description="List of frequently used important WORDs or terms in the document.",
     )

--- a/server/services/agents/recap_agent.py
+++ b/server/services/agents/recap_agent.py
@@ -1,7 +1,6 @@
 from operator import itemgetter
 from langchain_core.prompts import PromptTemplate
 from langchain_openai.chat_models import ChatOpenAI
-from langchain.callbacks.tracers import ConsoleCallbackHandler
 from ..storage import load_vectorstore
 from ..output_parsers.output_parsers import RecapOutput, recap_parser
 
@@ -50,7 +49,6 @@ def lookup() -> RecapOutput:
 
     recap_output = rag_chain.invoke(
         {"question": question},
-        config={"callbacks": [ConsoleCallbackHandler()]},
     )
 
     return recap_output

--- a/server/services/agents/recommendation_agent.py
+++ b/server/services/agents/recommendation_agent.py
@@ -2,7 +2,6 @@ from operator import itemgetter
 import json
 from langchain_core.prompts import PromptTemplate
 from langchain_openai.chat_models import ChatOpenAI
-from langchain.callbacks.tracers import ConsoleCallbackHandler
 from ..output_parsers.output_parsers import RecapOutput, RecommendationOutput, recommendation_parser
 
 
@@ -38,7 +37,6 @@ def lookup(recap_output: RecapOutput) -> RecommendationOutput:
 
     recommendation_output = rag_chain.invoke(
         {"racap": recap},
-        config={"callbacks": [ConsoleCallbackHandler()]},
     )
 
     return recommendation_output

--- a/server/services/embed.py
+++ b/server/services/embed.py
@@ -6,13 +6,11 @@ GET /embed
 import logging
 
 from pydantic import ValidationError
-from langchain_community.document_loaders import DirectoryLoader
 from langchain_community.vectorstores.chroma import Chroma
 from langchain_openai.embeddings import OpenAIEmbeddings
-from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from .ping import check_server_status
-from .storage import get_document_path, get_vectorstore_path
+from .storage import get_vectorstore_path, get_splitted_documents
 from .agents.recap_agent import lookup as recap_agent, RecapOutput
 from .agents.recommendation_agent import lookup as recommendation_agent
 from ..models.embed import EmbedOutput
@@ -97,28 +95,11 @@ def embed_document() -> bool:
     저장소에 있는 파일을 모델 서버로 보내 임베딩 결과를 받아옵니다.
     """
 
-    # 문서 파일 임베딩
-    document_path = get_document_path()
     vectorstore_path = get_vectorstore_path()
+    splitted_documents = get_splitted_documents()
 
     try:
-        # 디렉토리를 읽어옵니다. [Loader: UnstructuredFileLoader]
-        loader = DirectoryLoader(document_path, show_progress=True)
-        documents = loader.load()
-
-    except ValueError:
-        logging.warning("문서 임베딩 오류: 저장소를 읽을 수 없음")
-        return False
-
-    # 문서를 text_splitter로 자릅니다.
-    text_splitter = RecursiveCharacterTextSplitter(
-        chunk_size=1000,
-        chunk_overlap=200,
-        add_start_index=True,
-    )
-    splitted_documents = text_splitter.split_documents(documents)
-    try:
-        # 자른 문서를 persist 합니다.
+        # 자른 문서를 임베딩하고 동시에 persist 합니다.
         vectorstore = Chroma.from_documents(
             documents=splitted_documents,
             persist_directory=vectorstore_path,

--- a/server/services/upload.py
+++ b/server/services/upload.py
@@ -3,9 +3,17 @@ POST /upload
 에 사용되는 비즈니스 로직을 담은 코드 페이지입니다. 
 """
 from io import StringIO
-from pandas import read_csv
+from pandas import DataFrame
+import numpy as np
+from pydantic import BaseModel
 
-from .storage import clear_storage, save_file, load_df_path
+from .storage import clear_storage, save_file, load_dataframe
+
+
+class DatetimeRange(BaseModel):
+    column_name: str
+    min: str
+    max: str
 
 
 def upload_file(contents: bytes, filename: str, description: str) -> dict:
@@ -18,42 +26,71 @@ def upload_file(contents: bytes, filename: str, description: str) -> dict:
     save_file(contents, filename, description)
 
     # 테이블 데이터면 documentation을 추가로 생성합니다.
-    df_path = load_df_path()
-    if df_path:
-        save_table_documentation(table_name=description, df_path=df_path)
+    df = load_dataframe()
+    if isinstance(df, DataFrame):
+        save_table_documentation(table_name=description, df=df)
 
     return {"filename": filename, "description": description}
 
 
-def save_table_documentation(table_name: str, df_path: str):
+def save_table_documentation(table_name: str, df: DataFrame):
     """
     테이블을 설명하는 documentation을 만들어 텍스트 문서로 저장합니다.
     """
-    df = read_csv(df_path)
-
-    string_buffer = StringIO()
-    df.info(buf=string_buffer)
-    df_info = string_buffer.getvalue()
+    df_info = get_df_info(df=df)
+    datetime_ranges = get_datetime_ranges(df=df)
 
     documentation = f"""
-# table documentation
-- This document is a description of the table file attached by the retailer to request analysis of his/her data.
-- NOTE: The original title is '{table_name}', but a new name that matches the table information is needed. 
-
-## information of dataframe
-- Result of pd.DataFrame.info()
-- You can parse the necessary keywords by looking at them below.
-```
-{df_info}
-```
-
-## Brief table contents
-- First 5 rows of the DataFrame
-- can understand the flow of the document by looking below.
-```
+## 테이블 내용 요약
+- 이 테이블은 소매업자가 첨부한 데이터입니다. 
+- 테이블의 첫 5행 내용을 확인하여 문서의 흐름을 이해할 수 있습니다:
 {str(df.head())}
-```
+
+
+## 테이블 내용 유형
+- 테이블 내용의 유형은 아래와 같습니다:
+{str(df.dtypes)}
+
+
+## 테이블 내용 정보
+- pd.DataFrame.info()의 결과입니다.
+- 아래를 살펴보며 필요한 키워드를 파싱할 수 있습니다:
+{df_info}
+
 """
+
+    for datetime_range in datetime_ranges:
+        datetime_text = f"""
+## datetime format column "{datetime_range.column_name}" 추가 설명
+- {datetime_range.min} 부터 {datetime_range.max} 까지의 날짜 범위를 가집니다. 
+
+"""
+        documentation += datetime_text
+
+    # documentation 저장
     contents = documentation.encode(encoding="utf-8")
     description = f"{table_name}-documentation"
     save_file(contents=contents, filename="docs.txt", description=description)
+
+
+def get_df_info(df: DataFrame) -> str:
+    string_buffer = StringIO()
+    df.info(buf=string_buffer)
+    df_info = string_buffer.getvalue()
+    return df_info
+
+
+def get_datetime_ranges(df: DataFrame) -> list:
+    datetime_columns = df.select_dtypes(include=[np.datetime64])
+    datetime_ranges = []
+
+    # datetime_columns의 각 column들의 최소 date, 최대 date를 date_bandwidthes에 저장
+    for column in datetime_columns.columns:
+        datetime_range = DatetimeRange(
+            column_name=column,
+            min=str(df[column].min()),
+            max=str(df[column].max()),
+        )
+        datetime_ranges.append(datetime_range)
+
+    return datetime_ranges


### PR DESCRIPTION
## 직접 dataframe 가져오는 방식으로 변경
- 파일네임 건네주는 방식에서 데이터프레임 직접 전달하는 방식으로 바꿨어요. 
- 추가로 datetime에 매칭되는 column이 있으면 미리 등록해줘요. 
- AS-IS
```python
# services/storage.py
def load_df_path() -> str | None:
    """
    path에 있는 첫 번째 테이블 파일 경로를 전달하는 함수, 테이블 파일이 없다면 None을 반환합니다.
    """
    table_path = get_table_path()
    files_in_path = os.listdir(table_path)

    # 지원하는 확장자를 가진 파일 찾기
    table_file = next(

    if not table_file:
        return None

    file_path = os.path.join(table_path, table_file)
    return file_path


```

- TO-BE
```python
# services/storage.py
def load_dataframe():
    """
    테이블 파일을 불러와 dataframe으로 전달합니다. 파일이 없다면 None을 반환합니다.
    """
    table_path = get_table_path()
    files_in_path = os.listdir(table_path)

    # 지원하는 확장자를 가진 파일 찾기
    table_filename = next(
        (file for file in files_in_path if any(file.endswith(ext) for ext in TABLE_EXT)), None
    )

    if not table_filename:
        return None

    # df 불러오기
    try:
        table_file = os.path.join(table_path, table_filename)
        print(table_file)
        df = read_csv(table_file)

    except FileNotFoundError:
        logging.warning("load_dataframe 함수를 호출했으나 데이터 프레임을 가져올 수 없음")
        return None

    # to_datetime 정적으로 formatting
    date_words = ["date", "time", "날짜", "일자"]

    for column in df.columns:
        if any(word in column.lower() for word in date_words):
            df[column] = pd.to_datetime(df[column], errors="ignore")

    return df

# services/generate.py
df = load_dataframe()

```
## document split 모듈화
- document split하는 부분이 여러 곳에서 사용될 예정이라 모듈화했어요. 
- AS-IS
```python

# services/embed.py
def embed_document() -> bool:
    """
    저장소에 있는 파일을 모델 서버로 보내 임베딩 결과를 받아옵니다.
    """
    # 문서 파일 임베딩
    document_path = get_document_path()
    vectorstore_path = get_vectorstore_path()
    splitted_documents = get_splitted_documents()

    try:
        # 디렉토리를 읽어옵니다. [Loader: UnstructuredFileLoader]
        loader = DirectoryLoader(document_path, show_progress=True)
        documents = loader.load()

    except ValueError:
        logging.warning("문서 임베딩 오류: 저장소를 읽을 수 없음")
        return False

    # 문서를 text_splitter로 자릅니다.
    text_splitter = RecursiveCharacterTextSplitter(
        chunk_size=1000,
        chunk_overlap=200,
        add_start_index=True,
    )
    splitted_documents = text_splitter.split_documents(documents)
```

- TO-BE
```python
# services/storage.py
def get_splitted_documents(chunk_size=1000, chunk_overlap=0):
    """
    임베딩 또는 문서 요약에 사용하는 splitted documents를 가져옵니다.
    """
    document_path = get_document_path()
    try:
        # 디렉토리를 읽어옵니다. [Loader: UnstructuredFileLoader]
        loader = DirectoryLoader(document_path, show_progress=True)
        documents = loader.load()

    except ValueError:
        logging.warning("splitted documents 로딩 오류: 저장소를 읽을 수 없음")
        return None

    # 문서를 text_splitter로 자릅니다.
    text_splitter = RecursiveCharacterTextSplitter(
        chunk_size=chunk_size,
        chunk_overlap=chunk_overlap,
        add_start_index=True,
    )
    splitted_documents = text_splitter.split_documents(documents)
    return splitted_documents

# services/embed.py
def embed_document() -> bool:
    """
    저장소에 있는 파일을 모델 서버로 보내 임베딩 결과를 받아옵니다.
    """

    vectorstore_path = get_vectorstore_path()
    splitted_documents = get_splitted_documents()
```
