### PR TITLE
feat: recap 파이프라인 수정 (속도는 느리지만 확실한 녀석)

### DIFF
--- a/server/models/recommendation.py
+++ b/server/models/recommendation.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 
 class RecommendationOutput(BaseModel):
     recommendations: List[str] = Field(
-        description="Recommended questions for users to ask",
+        description="This is a list of questions that will best answer your questions.",
         min_items=3,
     )
 

--- a/server/services/agents/recap_agent.py
+++ b/server/services/agents/recap_agent.py
@@ -1,54 +1,61 @@
-from operator import itemgetter
 from langchain_core.prompts import PromptTemplate
 from langchain_openai.chat_models import ChatOpenAI
-from ..storage import load_vectorstore
+from langchain.chains.summarize import load_summarize_chain
+from ..storage import get_splitted_documents
 from ..output_parsers.output_parsers import RecapOutput, recap_parser
 
-RECAP_TEMPLATE = """Organize the title, flow, and main keywords of the document.
-Answer in the language Korean. Context is below: 
-```
-{context}
-```
-\n{format_instructions}"""
+MAP_PROMPT_TEMPLATE = """Write a concise summary of the following:
+
+{text}
+
+CONCISE SUMMARY in Korean:"""
+
+REDUCE_PROMPT_TEMPLATE = """The following is set of summaries:
+
+{text}
+
+Take these and distill it into a final, consolidated summary of the main themes. 
+
+{format_instructions}
+
+CONCISE FORMATTED SUMMARY in Korean:"""
 
 
 def lookup() -> RecapOutput:
     """
-    임베딩한 문서를 기반으로 요약 문서를 생성하는 Agent
-
-    # 문제 1. 문서를 제대로 못 물어옴 ㅠ 용량이 작으면 통째로 첨부할 예정
-    아래 링크로 리팩터링 예정
-    see more at :
-    https://python.langchain.com/docs/modules/data_connection/retrievers/multi_vector#summary
+    요약 문서를 생성하는 Agent
     """
     llm = ChatOpenAI(temperature=0.2, model_name="gpt-3.5-turbo")
 
-    vectorstore = load_vectorstore()
-    retriever = vectorstore.as_retriever(search_type="similarity", search_kwargs={"k": 3})
+    splitted_documents = get_splitted_documents(chunk_size=3000)
+    format_instructions = recap_parser.get_format_instructions()
 
-    rag_prompt = PromptTemplate(
-        template=RECAP_TEMPLATE,
-        input_variables=["context"],
-        partial_variables={"format_instructions": recap_parser.get_format_instructions()},
+    # Initialize templates
+
+    map_prompt = PromptTemplate(
+        input_variables=["text"],
+        template=MAP_PROMPT_TEMPLATE,
+    )
+    combine_prompt = PromptTemplate(
+        input_variables=["text"],
+        template=REDUCE_PROMPT_TEMPLATE,
+        partial_variables={"format_instructions": format_instructions},
     )
 
-    def format_docs(docs):
-        return "\n\n".join(doc.page_content for doc in docs)
-
-    question = "Organize the title, flow, and main keywords of the document."
-
-    # LCEL 정의
-    rag_chain = (
-        {
-            "context": itemgetter("question") | retriever | format_docs,
-        }
-        | rag_prompt
-        | llm
-        | recap_parser
+    chain = load_summarize_chain(
+        llm=llm,
+        chain_type="map_reduce",
+        return_intermediate_steps=True,
+        map_prompt=map_prompt,
+        combine_prompt=combine_prompt,
+        verbose=True,
     )
 
-    recap_output = rag_chain.invoke(
-        {"question": question},
-    )
+    result = chain.invoke({"input_documents": splitted_documents})
+    print(f"{result=}")
+
+    output_text = result["output_text"]
+
+    recap_output = recap_parser.parse(output_text)
 
     return recap_output

--- a/server/services/upload.py
+++ b/server/services/upload.py
@@ -41,14 +41,16 @@ def save_table_documentation(table_name: str, df: DataFrame):
     datetime_ranges = get_datetime_ranges(df=df)
 
     documentation = f"""
+# '{table_name}' 테이블 데이터 분석
+
 ## 테이블 내용 요약
 - 이 테이블은 소매업자가 첨부한 데이터입니다. 
 - 테이블의 첫 5행 내용을 확인하여 문서의 흐름을 이해할 수 있습니다:
 {str(df.head())}
 
 
-## 테이블 내용 유형
-- 테이블 내용의 유형은 아래와 같습니다:
+## 테이블 열 유형 분석
+- 테이블에 서술된 열들의 유형은 아래와 같습니다:
 {str(df.dtypes)}
 
 
@@ -61,8 +63,8 @@ def save_table_documentation(table_name: str, df: DataFrame):
 
     for datetime_range in datetime_ranges:
         datetime_text = f"""
-## datetime format column "{datetime_range.column_name}" 추가 설명
-- {datetime_range.min} 부터 {datetime_range.max} 까지의 날짜 범위를 가집니다. 
+## datetime "{datetime_range.column_name}" 추가 설명
+- {datetime_range.column_name}은 {datetime_range.min} 부터 {datetime_range.max} 까지의 날짜 범위를 가집니다. 
 
 """
         documentation += datetime_text


### PR DESCRIPTION
recap 아주 잘 생성하는 녀석으로 수정했습니다. 

- map reduce 적용
원리: 
1. 문서를 일정 토큰으로 잘라 작은 문서로 만든다
2. 작은 문서에 대한 요약을 굵직하고 짧게 생성한다
3. 모은 요약들로 최종 요약을 한다 -> recap 형태로 제공