### PR TITLE
Refactor OutputParser for accurate output format

### DIFF
--- a/server/models/recap.py
+++ b/server/models/recap.py
@@ -3,6 +3,10 @@ from pydantic import BaseModel, Field
 
 
 class RecapOutput(BaseModel):
+    """
+    Data model for a recap.
+    """
+
     title: str = Field(description="제목, 문서의 주요 주제를 간결하게 한 줄로 요약합니다.")
     subtitle: str = Field(description="하위 제목, 하위 주제를 지정하며 추가 정보를 제공합니다.")
     summary: str = Field(

--- a/server/models/recommendation.py
+++ b/server/models/recommendation.py
@@ -3,6 +3,10 @@ from pydantic import BaseModel, Field
 
 
 class RecommendationOutput(BaseModel):
+    """
+    Data model for a Recommendation.
+    """
+
     recommendations: List[str] = Field(
         description="""전체 맥락에서, 서로 다른 주제에 대해 물어보는 세 가지 질문 예시.
 한국어 존댓말과 함께, 물음표로 된 질문문 형식을 지켜야 합니다. 반드시 3개여야 합니다. """

--- a/server/services/agents/answer_document_agent.py
+++ b/server/services/agents/answer_document_agent.py
@@ -31,7 +31,9 @@ def lookup(message_input: str) -> Answer:
     engine = index.as_chat_engine(chat_mode=ChatMode.REACT, service_context=service_context)
 
     try:
-        message_input = f"Answer politely in Korean. {message_input}"
+        message_input = (
+            f"Thinking through several stages, answer politely in Korean. {message_input}"
+        )
         res = engine.chat(message_input)
         message = res.response
 

--- a/server/services/chains/recap.py
+++ b/server/services/chains/recap.py
@@ -1,9 +1,9 @@
 import logging
-from llama_index import ServiceContext
-from llama_index.output_parsers import LangchainOutputParser
+from llama_index import ServiceContext, SimpleDirectoryReader
 from llama_index.llms import OpenAI
-from server.services.storage import load_index
-from server.services.output_parsers.output_parsers import RecapOutput, recap_parser
+from llama_index.response_synthesizers import TreeSummarize
+from server.services.storage import get_document_path
+from server.models.recap import RecapOutput
 
 
 def generate_recap() -> RecapOutput:
@@ -19,28 +19,29 @@ def generate_recap() -> RecapOutput:
     """
     logging.info("recap chain 실행 ...")
 
-    query_message = """Create a Recap according to the instructions in Korean.
-Fill in the summary part abundantly."""
+    document_path = get_document_path()
+    documents = SimpleDirectoryReader(document_path).load_data()
 
-    index = load_index()
+    document_text = documents[0].text
+
     service_context = _load_service_context()
 
-    engine = index.as_query_engine(response_mode="tree_summarize", service_context=service_context)
+    summarizer = TreeSummarize(
+        service_context=service_context,
+        output_cls=RecapOutput,
+        verbose=True,
+    )
 
-    res = engine.query(query_message)
+    query_message = "Create a Recap in Korean. Fill in the summary part abundantly."
 
-    output_text = res.response
+    res = summarizer.get_response(query_str=query_message, text_chunks=[document_text])
+    logging.info("recap result: %s", res.to_dict())
 
-    recap_output = recap_parser.parse(output_text)
-    print(f"{recap_output}")
-    return recap_output
+    return res
 
 
 def _load_service_context():
 
-    # define output parser
-    output_parser = LangchainOutputParser(recap_parser)
-
-    llm = OpenAI(model="gpt-3.5-turbo-0125", output_parser=output_parser)
+    llm = OpenAI(model="gpt-3.5-turbo-0125")
     service_context = ServiceContext.from_defaults(llm=llm)
     return service_context

--- a/server/services/chains/recommendation.py
+++ b/server/services/chains/recommendation.py
@@ -1,12 +1,9 @@
 import logging
-from llama_index import ServiceContext
-from llama_index.output_parsers import LangchainOutputParser
+from llama_index import ServiceContext, SimpleDirectoryReader
 from llama_index.llms import OpenAI
-from server.services.output_parsers.output_parsers import (
-    RecommendationOutput,
-    recommendation_parser,
-)
-from server.services.storage import load_index
+from llama_index.response_synthesizers import TreeSummarize
+from server.services.storage import get_document_path
+from server.models.recommendation import RecommendationOutput
 
 
 def generate_recommendation() -> RecommendationOutput | None:
@@ -23,29 +20,30 @@ def generate_recommendation() -> RecommendationOutput | None:
 
     logging.info("recommendation chain 실행 ...")
 
-    index = load_index()
-    if index is None:
-        return None
+    document_path = get_document_path()
+    documents = SimpleDirectoryReader(document_path).load_data()
+
+    document_text = documents[0].text
+
     service_context = _load_service_context()
 
-    engine = index.as_query_engine(response_mode="tree_summarize", service_context=service_context)
-
-    query_message = """You are a retailer. 
+    summarizer = TreeSummarize(
+        service_context=service_context,
+        output_cls=RecommendationOutput,
+        verbose=True,
+    )
+    query_message = """You are a retailer.
 You want to ask a question to an AI chatbot that understands documents well.
 Create three questions in Korean that can be asked after looking at the content."""
 
-    res = engine.query(query_message)
+    res = summarizer.get_response(query_str=query_message, text_chunks=[document_text])
+    logging.info("recap result: %s", res.to_dict())
 
-    output_text = res.response
-    recommendation_output = recommendation_parser.parse(output_text)
-    return recommendation_output
+    return res
 
 
 def _load_service_context():
 
-    # define output parser
-    output_parser = LangchainOutputParser(recommendation_parser)
-
-    llm = OpenAI(model="gpt-3.5-turbo-0125", output_parser=output_parser)
+    llm = OpenAI(model="gpt-3.5-turbo-0125")
     service_context = ServiceContext.from_defaults(llm=llm)
     return service_context

--- a/server/services/storage.py
+++ b/server/services/storage.py
@@ -114,10 +114,22 @@ def load_dataframe():
     # df 불러오기
     try:
         table_file = os.path.join(table_path, table_filename)
-        df = read_csv(table_file)
+
+        # 지원되는 인코딩 찾기
+        encodings = ["utf-8", "euc-kr"]
+        for encoding in encodings:
+            try:
+                df = pd.read_csv(table_file, encoding=encoding)
+                break
+
+            except UnicodeDecodeError:
+                continue
+
+        else:
+            raise FileNotFoundError
 
     except FileNotFoundError:
-        logging.warning("load_dataframe 함수를 호출했으나 데이터 프레임을 가져올 수 없음")
+        logging.warning("데이터 프레임을 가져올 수 없음")
         return None
 
     # to_datetime 정적으로 formatting


### PR DESCRIPTION
기존 langchain의 OutputParser 에서
llamaindex로 바꾸면서 TreeSummarize (Synthesizer) 를 쓰는 게 더 대답을 잘 만들더라고요

1. v0.1.0 이전 구조 = langchain OutputParser: 문서 RAG 시 만족스럽지 못했음. 
2. AS-IS =  llamaindex OutputParser: OutputParser를 그대로 들고 올 수 없었음.
3. TO-BE = llamaindex TreeSummarize:  recap, recommendation 만드는 성능도 좋아지고, 파싱도 완벽하게 진행함.

오픈소스 모델로 돌렸을 때 OpenAI Function을 쓰지 못하는 단점이 있어서, recap, recommendation 부분은 OpenAI Function을 사용하지 않는 방면으로 추가 작업이 필요합니당