### PR TITLE
fix: langchain 특화 pydantic으로 라이브러리 수정

### DIFF
--- a/server/models/chart.py
+++ b/server/models/chart.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Union
 
-from pydantic import BaseModel, Field
+from langchain.pydantic_v1 import BaseModel, Field
 
 
 class ChartType(str, Enum):

--- a/server/models/generate.py
+++ b/server/models/generate.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from langchain.pydantic_v1 import BaseModel, Field
 
 from .chart import ChartOutput
 

--- a/server/models/ping.py
+++ b/server/models/ping.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from langchain.pydantic_v1 import BaseModel, Field
 
 
 # 서버 상태를 확인할 때 사용하는 모델

--- a/server/models/process.py
+++ b/server/models/process.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, Field
+from langchain.pydantic_v1 import BaseModel, Field
 
 from .chart import ChartOutput
 from .recap import RecapOutput

--- a/server/models/recap.py
+++ b/server/models/recap.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from pydantic import BaseModel, Field
+from langchain.pydantic_v1 import BaseModel, Field
 
 
 class RecapOutput(BaseModel):

--- a/server/models/recommendation.py
+++ b/server/models/recommendation.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from pydantic import BaseModel, Field
+from langchain.pydantic_v1 import BaseModel, Field
 
 
 class RecommendationOutput(BaseModel):

--- a/server/services/output_parsers/formatted_pydantic.py
+++ b/server/services/output_parsers/formatted_pydantic.py
@@ -4,10 +4,10 @@ from typing import TypeVar
 
 from langchain.chains import LLMChain
 from langchain.output_parsers import PydanticOutputParser
+from langchain.pydantic_v1 import BaseModel
 from langchain_core.exceptions import OutputParserException
 from langchain_core.prompts import PromptTemplate
 from langchain_openai.chat_models import ChatOpenAI
-from pydantic import BaseModel
 
 
 JSON_FORMATTING_TEMPLATE = """{format_instructions}

--- a/server/services/process.py
+++ b/server/services/process.py
@@ -9,10 +9,10 @@ from typing import Any
 
 import faiss
 
+from langchain.pydantic_v1_core import ValidationError
 from langchain_core.exceptions import OutputParserException
 from llama_index import SimpleDirectoryReader, StorageContext, VectorStoreIndex
 from llama_index.vector_stores.faiss import FaissVectorStore
-from pydantic_core import ValidationError
 
 from ..models.chart import ChartType
 from ..models.process import ProcessOutput, ProcessType

--- a/server/services/upload.py
+++ b/server/services/upload.py
@@ -5,8 +5,8 @@ POST /upload
 
 import numpy as np
 
+from langchain.pydantic_v1 import BaseModel
 from pandas import DataFrame
-from pydantic import BaseModel
 
 from .storage import clear_storage, load_dataframe, save_file
 


### PR DESCRIPTION
일반적인 pydantic은 pydantic(version 2)라서, langchain 호환 pydantic.v1으로 맞춰줘야 해요. 
AS-IS:
```python
from pydantic
```

TO-BE:
```python
from langchain.pydantic_v1 
```
수정했습니다. 
